### PR TITLE
Update clang-tidy-post-review-comments.yml

### DIFF
--- a/.github/workflows/clang-tidy-post-review-comments.yml
+++ b/.github/workflows/clang-tidy-post-review-comments.yml
@@ -12,3 +12,5 @@ jobs:
 
     steps:
       - uses: ZedThree/clang-tidy-review/post@v0.19.0
+        with:
+          num_comments_as_exitcode: false


### PR DESCRIPTION
The workflow's intention is simply to post comments, so I don't want the workflow to report as having failed when it posts comments. So I set the option `num_comments_as_exitcode` to false.