### PR TITLE
Update _config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@ title: CLArgs Documentation
 description: The documentation for the CLArgs command-line argument parsing library.
 theme: just-the-docs
 
-url: https://rubensorensen.github.io/clargs/
+url: https://rsore.github.io/clargs/
 
 aux_links:
-  Template Repository: https://github.com/rubensorensen/clargs
+  Github Repository: https://github.com/rsore/clargs


### PR DESCRIPTION
## Pull Request

### Description
When using the [just-the-docs template](https://just-the-docs.com/) for jekyll, I accidentally left in a redundant link to the template itself. In this development branch I have replaced this with a link to the github repository of CLArgs. I also renamed my github user some time ago, so the link to the github page was also outdated, so I updated that.

### Related Issues
N/A

### How Has This Been Tested?
N/A

### Code Quality Checks
Please ensure that your code passes the following checks before submitting your pull request:
- [x] **clang-format**: My code is formatted according to the project's `clang-format` configuration.
- [x] **clang-tidy**: My code passes `clang-tidy` checks with no new warnings.

### Checklist
Please review and complete the following checklist:
- [x] I have added/updated tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation if necessary.
- [x] My changes are self-contained and do not break existing functionality.
- [x] I have attached the appropriate labels to this pull request (e.g., `feature`, `bug`, `improvement`, etc.).