### PR TITLE
31 replace underlying option value datastructure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-24.04]
     
     steps:
     - uses: actions/checkout@v4
-    - name: install dependencies
-      run: sudo apt-get install build-essential libssl-dev -y
+    - name: Update apt repository
+      run: sudo apt-get update -y
+    - name: install basic dependencies
+      run: sudo apt-get install build-essential libssl-dev
+    - name: Install gcc14 and make it the default compiler
+      run: |
+        sudo add-apt-repository universe
+        sudo apt update -qq
+        sudo apt install -y gcc-14 g++-14 libpcre3 liblapack-dev
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 60 --slave /usr/bin/g++ g++ /usr/bin/g++-14
     - name: configure
       run: mkdir build && cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Debug
     - name: make

--- a/examples/01_basic/main.cpp
+++ b/examples/01_basic/main.cpp
@@ -29,6 +29,10 @@ main(int argc, char **argv)
     {
         std::cout << "Config file: " << config.value() << std::endl;
     }
+    else
+    {
+        std::cout << "No config file provided." << std::endl;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/include/CLArgs/core.hpp
+++ b/include/CLArgs/core.hpp
@@ -129,7 +129,8 @@ CLArgs::array_from_delimited_string()
 
     std::ranges::transform(std::views::split(strv, delimiter),
                            result.begin(),
-                           [](const auto &segment) { return std::string_view{segment.data(), segment.size()}; });
+                           [](const auto &segment)
+                           { return std::string_view{segment.begin(), static_cast<std::size_t>(std::ranges::distance(segment))}; });
 
     return result;
 }

--- a/include/CLArgs/core.hpp
+++ b/include/CLArgs/core.hpp
@@ -129,10 +129,7 @@ CLArgs::array_from_delimited_string()
 
     std::ranges::transform(std::views::split(strv, delimiter),
                            result.begin(),
-                           [](const auto &segment)
-                           {
-                               return std::string_view{segment.data(), segment.size()};
-                           });
+                           [](const auto &segment) { return std::string_view{segment.data(), segment.size()}; });
 
     return result;
 }

--- a/include/CLArgs/core.hpp
+++ b/include/CLArgs/core.hpp
@@ -4,8 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <concepts>
-#include <cstdint>
-#include <iostream>
+#include <cstddef>
 #include <string_view>
 
 namespace CLArgs
@@ -65,6 +64,37 @@ namespace CLArgs
 
     template <typename T, typename... Ts>
     concept IsPartOf = (std::is_same_v<T, Ts> || ...);
+
+    template <typename...>
+    struct AllUnique : std::true_type
+    {
+    };
+
+    template <typename First, typename... Rest>
+    struct AllUnique<First, Rest...> : std::conditional_t<IsPartOf<First, Rest...>, std::false_type, AllUnique<Rest...>>
+    {
+    };
+
+    template <typename... Ts>
+    inline constexpr bool AllUnique_v = AllUnique<Ts...>::value;
+
+    template <typename T, typename Tuple>
+    struct TupleTypeIndex;
+
+    template <typename T, typename... Types>
+    struct TupleTypeIndex<T, std::tuple<T, Types...>>
+    {
+        static constexpr std::size_t value{0};
+    };
+
+    template <typename T, typename U, typename... Types>
+    struct TupleTypeIndex<T, std::tuple<U, Types...>>
+    {
+        static constexpr std::size_t value = 1 + TupleTypeIndex<T, std::tuple<Types...>>::value;
+    };
+
+    template <typename T, typename Tuple>
+    inline constexpr std::size_t TupleTypeIndex_v = TupleTypeIndex<T, Tuple>::value;
 
     template <Parsable Parsable>
     static consteval std::size_t identifier_list_length();


### PR DESCRIPTION
## Description
In this development branch I have implemented the proposed changes in #31, replacing the underlying datastructure of [`ValueContainer`](https://github.com/rsore/clargs/blob/059b7aa244a2e19788ae46ca8b84705a8ae39bd5/include/CLArgs/value_container.hpp) with a much more memory-efficient solution, without sacrificing safety or run-time performance.

Essentially the change moves the type of the underlying datastructure from `std::array<std::variant<std::optional<typename Option::ValueType>...>>` to `std::tuple<std::optional<typename Option::ValueType>...>`.
The previous solution of using `std::variant` did work fine, but the issue was that it forces all elements of the array to be the same size, meaning if most value types of the parser takes up a small amount of bytes, but you have a single larger value type, the size of all of them will be forced to the largest size.

Using `std::tuple`, we can store the values as their exact parsed type, leading to no memory overhead at all. Since the indices of all options are known at compile-time, setting and retrieving values from the container essentially becomes a direct variable lookup, insanely fast!

An additional improvement, though irrelevant to the real scope of this branch, is that I have refactored part of the `array_from_delimited_string` function. Specifically, I have updated the part of the code that segments the string and appends the views to the resulting array. Previously this was done through manual logic, and the code was a bit hard to follow. Now I utilize a combination of [`std::views::split`](https://en.cppreference.com/w/cpp/ranges/split_view) and [`std::ranges::transform`](https://en.cppreference.com/w/cpp/ranges/transform_view) to do both the segmentation and appending in a concise manner.

Finally, due to the usage of modern C++20 features, I have had to update the gcc compiler for the test workflow to use gcc14. gcc13 would likely do, but why not just be more modern, it might potentially catch more errors.

## Related Issues
Closes #31.

## How Has This Been Tested?
The datastructure itself has been closely observed using the debugger to ensure that the data is layed out as expected before, during and after parsing. Functionally there is no change, so no new tests have been introduced, but all existing tests still pass.