### PR TITLE
Improve array generation in array_from_delimited_string

### DIFF
--- a/include/CLArgs/core.hpp
+++ b/include/CLArgs/core.hpp
@@ -129,8 +129,11 @@ CLArgs::array_from_delimited_string()
 
     std::ranges::transform(std::views::split(strv, delimiter),
                            result.begin(),
-                           [](const auto &segment)
-                           { return std::string_view{segment.begin(), static_cast<std::size_t>(std::ranges::distance(segment))}; });
+                           [](const auto &segment) -> std::string_view
+                           {
+                               const auto length = static_cast<std::size_t>(std::ranges::distance(segment));
+                               return {segment.begin(), length};
+                           });
 
     return result;
 }


### PR DESCRIPTION
Very small, isolated change. Simply attempts to make the segmentation of string_views in `array_from_delimited_string` more readable. The lambda passed to `std::ranges::transform` has been updated, and now looks like:

```cpp
std::ranges::transform(std::views::split(strv, delimiter),
                       result.begin(),
                       [](const auto &segment) -> std::string_view
                       {
                           const auto length = static_cast<std::size_t>(std::ranges::distance(segment));
                           return {segment.begin(), length};
                       });
```