### PR TITLE
Add reset() method to ValueContainer

### DIFF
--- a/include/CLArgs/value_container.hpp
+++ b/include/CLArgs/value_container.hpp
@@ -23,6 +23,8 @@ namespace CLArgs
         template <Parsable T>
         [[nodiscard]] const std::optional<typename T::ValueType> &get_value() const;
 
+        void reset();
+
     private:
         template <Parsable T>
         static consteval std::size_t index_of_type();
@@ -56,6 +58,13 @@ CLArgs::ValueContainer<Parsables...>::get_value() const
     constexpr std::size_t index = index_of_type<T>();
     static_assert(std::is_same_v<std::tuple_element_t<index, ValuesTuple>, std::optional<typename T::ValueType>>);
     return std::get<index>(values_);
+}
+
+template <CLArgs::Parsable... Parsables>
+void
+CLArgs::ValueContainer<Parsables...>::reset()
+{
+    values_ = std::make_tuple(std::optional<typename Parsables::ValueType>{}...);
 }
 
 template <CLArgs::Parsable... Parsables>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(CLArgsTests
         parser_tests.cpp
         parse_value_tests.cpp
         test_utils.hpp
+        value_container_tests.cpp
 )
 
 target_compile_options(CLArgsTests PRIVATE

--- a/tests/value_container_tests.cpp
+++ b/tests/value_container_tests.cpp
@@ -1,0 +1,74 @@
+#include <CLArgs/core.hpp>
+#include <CLArgs/value_container.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+using VerboseFlag = CLArgs::Flag<"--verbose,-v", "Enable verbose output">;
+using FileOption  = CLArgs::Option<"--file", "FILE", "Specify file to load", std::filesystem::path>;
+
+TEST_CASE("Empty ValueContainer contains all std::nullopt", "[value_container]")
+{
+    CLArgs::ValueContainer<VerboseFlag, FileOption> container;
+
+    REQUIRE_FALSE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE(container.get_value<VerboseFlag>() == std::nullopt);
+
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+    REQUIRE(container.get_value<FileOption>() == std::nullopt);
+}
+
+TEST_CASE("Values can be inserted into ValueContainer, and safely retrieved", "[value_container]")
+{
+    CLArgs::ValueContainer<VerboseFlag, FileOption> container;
+
+    REQUIRE_FALSE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+
+    container.set_value<VerboseFlag>(false);
+    REQUIRE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE(container.get_value<VerboseFlag>().value() == false);
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+
+    container.set_value<VerboseFlag>(true);
+    REQUIRE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE(container.get_value<VerboseFlag>().value() == true);
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+
+    container.set_value<FileOption>("conf.ini");
+    REQUIRE(container.get_value<FileOption>().has_value());
+    REQUIRE(container.get_value<FileOption>().value() == "conf.ini");
+
+    container.set_value<FileOption>("configuration_file.txt");
+    REQUIRE(container.get_value<FileOption>().has_value());
+    REQUIRE(container.get_value<FileOption>().value() == "configuration_file.txt");
+}
+
+TEST_CASE("Values in ValueContainer can be reset to std::nullopt using reset()", "[value_container]")
+{
+    CLArgs::ValueContainer<VerboseFlag, FileOption> container;
+
+    REQUIRE_FALSE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+
+    container.set_value<VerboseFlag>(true);
+    REQUIRE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE(container.get_value<VerboseFlag>().value() == true);
+
+    container.set_value<FileOption>("conf.ini");
+    REQUIRE(container.get_value<FileOption>().has_value());
+    REQUIRE(container.get_value<FileOption>().value() == "conf.ini");
+
+    container.reset();
+    REQUIRE_FALSE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE_FALSE(container.get_value<FileOption>().has_value());
+
+    container.set_value<VerboseFlag>(false);
+    REQUIRE(container.get_value<VerboseFlag>().has_value());
+    REQUIRE(container.get_value<VerboseFlag>().value() == false);
+
+    container.set_value<FileOption>("new_config.ini");
+    REQUIRE(container.get_value<FileOption>().has_value());
+    REQUIRE(container.get_value<FileOption>().value() == "new_config.ini");
+}


### PR DESCRIPTION
## Description
In this development branch I have added a utility function in the [`ValueContainer`](https://github.com/rsore/clargs/blob/2260b26821276d691e0d2e3a5f55908dd7f14af2/include/CLArgs/value_container.hpp) class, `reset()`. It simply resets the internal tuple to contain all `std::nullopt`. 

This utility function does not yet serve any purpose for the [`Parser`](https://github.com/rsore/clargs/blob/2260b26821276d691e0d2e3a5f55908dd7f14af2/include/CLArgs/parser.hpp) at this time, but will likely be necessary later. I want the parser itself to be re-usable to parse several sets of arguments, and instead of creating a new `ValueContainer` each time, I would prefer to just reset the `ValueContainer`.

## How Has This Been Tested?
I have implemented unit tests for the already existing `ValueContainer` functions, as well as for the new `reset()` function.