### PR TITLE
Remove CodeQL badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![tests](https://github.com/rubensorensen/clargs/actions/workflows/tests.yml/badge.svg)](https://github.com/rubensorensen/clargs/actions/workflows/tests.yml)
 [![docs](https://github.com/rubensorensen/clargs/actions/workflows/docs.yml/badge.svg)](https://github.com/rubensorensen/clargs/actions/workflows/docs.yml)
-[![CodeQL](https://github.com/rsore/clargs/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/rsore/clargs/actions/workflows/github-code-scanning/codeql)
 [![formatting](https://github.com/rsore/clargs/actions/workflows/clang-format.yml/badge.svg)](https://github.com/rsore/clargs/actions/workflows/clang-format.yml)
 [![static-code-analysis](https://github.com/rsore/clargs/actions/workflows/clang-tidy-analysis.yml/badge.svg)](https://github.com/rsore/clargs/actions/workflows/clang-tidy-analysis.yml)
 


### PR DESCRIPTION
CodeQL is no longer used in the repo, so it makes little sense to keep the badge in the README.md file. I have therefore removed it in this development branch.