### PR TITLE
Update README.md to use ParserBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ using ConfigOption  = CLArgs::Option<"--config,--configuration,-c", "<filepath>"
 int
 main(int argc, char **argv)
 {
-    CLArgs::Parser<VerboseFlag, ConfigOption> parser;
+    CLArgs::Parser parser = CLArgs::ParserBuilder{}
+                                .add_program_description<"Example program.">()
+                                .add_flag<VerboseFlag>()
+                                .add_option<ConfigOption>()
+                                .build();
     try
     {
         parser.parse(argc, argv);


### PR DESCRIPTION
#37 introduced the `ParserBuilder`, and is the preferred API for defining a parser. As such, it makes sense to update the example in the readme file to use this. I just forgot to update it initially.