### PR TITLE
Add common flags and options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(CLArgs INTERFACE
         include/CLArgs/value_container.hpp
         include/CLArgs/parser_builder.hpp
         include/CLArgs/common_flags.hpp
+        include/CLArgs/common_options.hpp
 )
 
 target_include_directories(CLArgs INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(CLArgs INTERFACE
         include/CLArgs/parse_value.hpp
         include/CLArgs/value_container.hpp
         include/CLArgs/parser_builder.hpp
+        include/CLArgs/common_flags.hpp
 )
 
 target_include_directories(CLArgs INTERFACE

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ using ConfigOption  = CLArgs::Option<"--config,--configuration,-c", "<filepath>"
 int
 main(int argc, char **argv)
 {
-    CLArgs::Parser parser = CLArgs::ParserBuilder{}
-                                .add_program_description<"Example program.">()
-                                .add_flag<VerboseFlag>()
-                                .add_option<ConfigOption>()
-                                .build();
+    auto parser = CLArgs::ParserBuilder{}
+                      .add_program_description<"Example program.">()
+                      .add_flag<VerboseFlag>()
+                      .add_option<ConfigOption>()
+                      .build();
     try
     {
         parser.parse(argc, argv);

--- a/examples/01_basic/main.cpp
+++ b/examples/01_basic/main.cpp
@@ -10,12 +10,12 @@ using ConfigOption = CLArgs::Option<"--config,--configuration,-c", "<filepath>",
 int
 main(int argc, char **argv)
 {
-    CLArgs::Parser parser = CLArgs::ParserBuilder{}
-                                .add_program_description<"Basic example program to showcase CLArgs library.">()
-                                .add_flag<HelpFlag>()
-                                .add_flag<VerboseFlag>()
-                                .add_option<ConfigOption>()
-                                .build();
+    auto parser = CLArgs::ParserBuilder{}
+                      .add_program_description<"Basic example program to showcase CLArgs library.">()
+                      .add_flag<HelpFlag>()
+                      .add_flag<VerboseFlag>()
+                      .add_option<ConfigOption>()
+                      .build();
     try
     {
         parser.parse(argc, argv);

--- a/include/CLArgs/common_flags.hpp
+++ b/include/CLArgs/common_flags.hpp
@@ -5,18 +5,18 @@
 
 namespace CLArgs::CommonFlags
 {
-    using Help         = Flag<"--help,-h", "Show help menu">;
-    using Verbose      = Flag<"--verbose,-v", "Enable verbose output">;
-    using Quiet        = Flag<"--quiet,-q", "Enable quiet output">;
-    using Version      = Flag<"--version", "Show program version">;
-    using Recursive    = Flag<"--recursive,-r", "Enable recursive mode">;
     using All          = Flag<"--all,-a", "Include all">;
-    using Force        = Flag<"--force,-f", "Force the action">;
-    using Parallel     = Flag<"--parallel", "Enable parallel execution">;
-    using Experimental = Flag<"--experimental", "Enable experimental features">;
-    using Profile      = Flag<"--profile", "Profile program performance">;
     using Debug        = Flag<"--debug", "Run in debug mode">;
+    using Experimental = Flag<"--experimental", "Enable experimental features">;
+    using Force        = Flag<"--force,-f", "Force the action">;
+    using Help         = Flag<"--help,-h", "Show help menu">;
     using Overwrite    = Flag<"--overwrite", "Allow overwriting existing data">;
+    using Parallel     = Flag<"--parallel", "Enable parallel execution">;
+    using Profile      = Flag<"--profile", "Profile program performance">;
+    using Quiet        = Flag<"--quiet,-q", "Enable quiet output">;
+    using Recursive    = Flag<"--recursive,-r", "Enable recursive mode">;
+    using Verbose      = Flag<"--verbose,-v", "Enable verbose output">;
+    using Version      = Flag<"--version", "Show program version">;
 } // namespace CLArgs::CommonFlags
 
 #endif

--- a/include/CLArgs/common_flags.hpp
+++ b/include/CLArgs/common_flags.hpp
@@ -1,0 +1,11 @@
+#ifndef CLARGS_COMMON_FLAGS_HPP
+#define CLARGS_COMMON_FLAGS_HPP
+
+#include <CLArgs/core.hpp>
+
+namespace CLArgs::CommonFlags
+{
+    using Verbose = Flag<"--verbose,-v", "Enable verbose output">;
+}
+
+#endif

--- a/include/CLArgs/common_flags.hpp
+++ b/include/CLArgs/common_flags.hpp
@@ -5,7 +5,9 @@
 
 namespace CLArgs::CommonFlags
 {
+    using Help    = Flag<"--help,-h", "Show help menu">;
     using Verbose = Flag<"--verbose,-v", "Enable verbose output">;
-}
+    using Quiet   = Flag<"--quiet,-q", "Enable quiet output">;
+} // namespace CLArgs::CommonFlags
 
 #endif

--- a/include/CLArgs/common_flags.hpp
+++ b/include/CLArgs/common_flags.hpp
@@ -5,9 +5,18 @@
 
 namespace CLArgs::CommonFlags
 {
-    using Help    = Flag<"--help,-h", "Show help menu">;
-    using Verbose = Flag<"--verbose,-v", "Enable verbose output">;
-    using Quiet   = Flag<"--quiet,-q", "Enable quiet output">;
+    using Help         = Flag<"--help,-h", "Show help menu">;
+    using Verbose      = Flag<"--verbose,-v", "Enable verbose output">;
+    using Quiet        = Flag<"--quiet,-q", "Enable quiet output">;
+    using Version      = Flag<"--version", "Show program version">;
+    using Recursive    = Flag<"--recursive,-r", "Enable recursive mode">;
+    using All          = Flag<"--all,-a", "Include all">;
+    using Force        = Flag<"--force,-f", "Force the action">;
+    using Parallel     = Flag<"--parallel", "Enable parallel execution">;
+    using Experimental = Flag<"--experimental", "Enable experimental features">;
+    using Profile      = Flag<"--profile", "Profile program performance">;
+    using Debug        = Flag<"--debug", "Run in debug mode">;
+    using Overwrite    = Flag<"--overwrite", "Allow overwriting existing data">;
 } // namespace CLArgs::CommonFlags
 
 #endif

--- a/include/CLArgs/common_options.hpp
+++ b/include/CLArgs/common_options.hpp
@@ -1,0 +1,13 @@
+#ifndef CLARGS_COMMON_OPTIONS_HPP
+#define CLARGS_COMMON_OPTIONS_HPP
+
+#include <CLArgs/core.hpp>
+
+#include <filesystem>
+
+namespace CLArgs::CommonOptions
+{
+    using Config = Option<"--configuration,--config", "<filepath>", "Specify the path to configuration file", std::filesystem::path>;
+}
+
+#endif

--- a/include/CLArgs/common_options.hpp
+++ b/include/CLArgs/common_options.hpp
@@ -3,11 +3,23 @@
 
 #include <CLArgs/core.hpp>
 
+#include <chrono>
+#include <cstdint>
 #include <filesystem>
+#include <string>
 
 namespace CLArgs::CommonOptions
 {
-    using Config = Option<"--configuration,--config", "<filepath>", "Specify the path to configuration file", std::filesystem::path>;
-}
+    using Config     = Option<"--configuration,--config", "<filepath>", "Specify the config file path", std::filesystem::path>;
+    using Output     = Option<"--output,-o", "<filepath>", "Specify the output file path", std::filesystem::path>;
+    using Input      = Option<"--input,-i", "<filepath>", "Specify the input file path", std::filesystem::path>;
+    using Timeout    = Option<"--timeout", "<seconds>", "Specify the timeout duration in seconds", std::chrono::seconds>;
+    using Ip         = Option<"--ip,--address", "<ip address>", "Specify the IP address", std::string>;
+    using Port       = Option<"--port", "<number>", "Specify the port number", std::uint16_t>;
+    using Threads    = Option<"--threads", "<number>", "Specify the number of threads", std::uint16_t>;
+    using Username   = Option<"--username,--user", "<username>", "Specify the username", std::string>;
+    using Password   = Option<"--password,--pass", "<password>", "Specify the password", std::string>;
+    using MaxRetries = Option<"--max-retries", "<number>", "Specify the maximum number of retries", std::uint32_t>;
+} // namespace CLArgs::CommonOptions
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(CLArgsTests
         test_utils.hpp
         value_container_tests.cpp
         parser_builder_tests.cpp
+        common_flags_tests.cpp
 )
 
 target_compile_options(CLArgsTests PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(CLArgsTests
         value_container_tests.cpp
         parser_builder_tests.cpp
         common_flags_tests.cpp
+        common_options_tests.cpp
 )
 
 target_compile_options(CLArgsTests PRIVATE

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -14,7 +14,7 @@ template <CLArgs::CmdFlag Flag>
 constexpr void
 test_flag_not_passed()
 {
-    SECTION("Not passed")
+    SECTION("Flag not passed to parser")
     {
         FlagTesterParser<Flag> parser;
         constexpr std::array   args = {"program"};
@@ -28,7 +28,7 @@ template <CLArgs::CmdFlag Flag, CLArgs::StringLiteral Identifier, CLArgs::String
 constexpr void
 test_flag_passed()
 {
-    SECTION("Pass " + std::string(Identifier.value))
+    SECTION("Pass argument \"" + std::string(Identifier.value) + "\" to parser")
     {
         FlagTesterParser<Flag> parser;
         constexpr std::array   args = {"program", Identifier.value};
@@ -64,4 +64,49 @@ TEST_CASE("Parser with CommonFlags::Verbose", "[common_flags]")
 TEST_CASE("Parser with CommonFlags::Quiet", "[common_flags]")
 {
     test_flag<CLArgs::CommonFlags::Quiet, "--quiet", "-q">();
+}
+
+TEST_CASE("Parser with CommonFlags::Version", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Version, "--version">();
+}
+
+TEST_CASE("Parser with CommonFlags::Recursive", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Recursive, "--recursive", "-r">();
+}
+
+TEST_CASE("Parser with CommonFlags::All", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::All, "--all", "-a">();
+}
+
+TEST_CASE("Parser with CommonFlags::Force", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Force, "--force", "-f">();
+}
+
+TEST_CASE("Parser with CommonFlags::Parallel", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Parallel, "--parallel">();
+}
+
+TEST_CASE("Parser with CommonFlags::Experimental", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Experimental, "--experimental">();
+}
+
+TEST_CASE("Parser with CommonFlags::Profile", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Profile, "--profile">();
+}
+
+TEST_CASE("Parser with CommonFlags::Debug", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Debug, "--debug">();
+}
+
+TEST_CASE("Parser with CommonFlags::Overwrite", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Overwrite, "--overwrite">();
 }

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -10,7 +10,7 @@ template <CLArgs::CmdFlag Flag>
 using FlagTesterParser = decltype(CLArgs::ParserBuilder{}.add_flag<Flag>().build());
 
 template <CLArgs::CmdFlag Flag>
-constexpr void
+void
 test_flag_not_passed()
 {
     SECTION("Flag not passed to parser")
@@ -24,7 +24,7 @@ test_flag_not_passed()
 }
 
 template <CLArgs::CmdFlag Flag, CLArgs::StringLiteral Identifier, CLArgs::StringLiteral... Identifiers>
-constexpr void
+void
 test_flag_passed()
 {
     SECTION("Pass argument \"" + std::string(Identifier.value) + "\" to parser")
@@ -43,7 +43,7 @@ test_flag_passed()
 }
 
 template <CLArgs::CmdFlag Flag, CLArgs::StringLiteral... Identifiers>
-constexpr void
+void
 test_flag()
 {
     test_flag_not_passed<Flag>();

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -7,31 +7,61 @@
 
 #include <array>
 
-TEST_CASE("Parser with CommonFlags::Verbose", "[flag_parsing]")
-{
-    auto parser = CLArgs::ParserBuilder{}.add_flag<CLArgs::CommonFlags::Verbose>().build();
+template <CLArgs::CmdFlag Flag>
+using FlagTesterParser = decltype(CLArgs::ParserBuilder{}.add_flag<Flag>().build());
 
+template <CLArgs::CmdFlag Flag>
+constexpr void
+test_flag_not_passed()
+{
     SECTION("Not passed")
     {
-        constexpr std::array args = {"program"};
-        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
+        FlagTesterParser<Flag> parser;
+        constexpr std::array   args = {"program"};
+        auto [argc, argv]           = CLArgs::Testing::create_argc_argv_from_array(args);
         REQUIRE_NOTHROW(parser.parse(argc, argv));
-        CHECK_FALSE(parser.has_flag<CLArgs::CommonFlags::Verbose>());
+        CHECK_FALSE(parser.template has_flag<Flag>());
+    }
+}
+
+template <CLArgs::CmdFlag Flag, CLArgs::StringLiteral Identifier, CLArgs::StringLiteral... Identifiers>
+constexpr void
+test_flag_passed()
+{
+    SECTION("Pass " + std::string(Identifier.value))
+    {
+        FlagTesterParser<Flag> parser;
+        constexpr std::array   args = {"program", Identifier.value};
+        auto [argc, argv]           = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK(parser.template has_flag<Flag>());
     }
 
-    SECTION("Pass -v")
+    if constexpr (sizeof...(Identifiers) > 0)
     {
-        constexpr std::array args = {"program", "-v"};
-        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
-        REQUIRE_NOTHROW(parser.parse(argc, argv));
-        CHECK(parser.has_flag<CLArgs::CommonFlags::Verbose>());
+        test_flag_passed<Flag, Identifiers...>();
     }
+}
 
-    SECTION("Pass --verbose")
-    {
-        constexpr std::array args = {"program", "--verbose"};
-        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
-        REQUIRE_NOTHROW(parser.parse(argc, argv));
-        CHECK(parser.has_flag<CLArgs::CommonFlags::Verbose>());
-    }
+template <CLArgs::CmdFlag Flag, CLArgs::StringLiteral... Identifiers>
+constexpr void
+test_flag()
+{
+    test_flag_not_passed<Flag>();
+    test_flag_passed<Flag, Identifiers...>();
+}
+
+TEST_CASE("Parser with CommonFlags::Help", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Help, "--help", "-h">();
+}
+
+TEST_CASE("Parser with CommonFlags::Verbose", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Verbose, "--verbose", "-v">();
+}
+
+TEST_CASE("Parser with CommonFlags::Quiet", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Quiet, "--quiet", "-q">();
 }

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -1,0 +1,37 @@
+#include <CLArgs/common_flags.hpp>
+#include <CLArgs/parser.hpp>
+#include <CLArgs/parser_builder.hpp>
+#include "test_utils.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+
+TEST_CASE("Parser with CommonFlags::Verbose", "[flag_parsing]")
+{
+    CLArgs::Parser parser = CLArgs::ParserBuilder{}.add_flag<CLArgs::CommonFlags::Verbose>().build();
+
+    SECTION("Not passed")
+    {
+        constexpr std::array args = {"program"};
+        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK_FALSE(parser.has_flag<CLArgs::CommonFlags::Verbose>());
+    }
+
+    SECTION("Pass -v")
+    {
+        constexpr std::array args = {"program", "-v"};
+        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK(parser.has_flag<CLArgs::CommonFlags::Verbose>());
+    }
+
+    SECTION("Pass --verbose")
+    {
+        constexpr std::array args = {"program", "--verbose"};
+        auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK(parser.has_flag<CLArgs::CommonFlags::Verbose>());
+    }
+}

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -1,5 +1,4 @@
 #include <CLArgs/common_flags.hpp>
-#include <CLArgs/parser.hpp>
 #include <CLArgs/parser_builder.hpp>
 #include "test_utils.hpp"
 
@@ -51,54 +50,9 @@ test_flag()
     test_flag_passed<Flag, Identifiers...>();
 }
 
-TEST_CASE("Parser with CommonFlags::Help", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Help, "--help", "-h">();
-}
-
-TEST_CASE("Parser with CommonFlags::Verbose", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Verbose, "--verbose", "-v">();
-}
-
-TEST_CASE("Parser with CommonFlags::Quiet", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Quiet, "--quiet", "-q">();
-}
-
-TEST_CASE("Parser with CommonFlags::Version", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Version, "--version">();
-}
-
-TEST_CASE("Parser with CommonFlags::Recursive", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Recursive, "--recursive", "-r">();
-}
-
 TEST_CASE("Parser with CommonFlags::All", "[common_flags]")
 {
     test_flag<CLArgs::CommonFlags::All, "--all", "-a">();
-}
-
-TEST_CASE("Parser with CommonFlags::Force", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Force, "--force", "-f">();
-}
-
-TEST_CASE("Parser with CommonFlags::Parallel", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Parallel, "--parallel">();
-}
-
-TEST_CASE("Parser with CommonFlags::Experimental", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Experimental, "--experimental">();
-}
-
-TEST_CASE("Parser with CommonFlags::Profile", "[common_flags]")
-{
-    test_flag<CLArgs::CommonFlags::Profile, "--profile">();
 }
 
 TEST_CASE("Parser with CommonFlags::Debug", "[common_flags]")
@@ -106,7 +60,52 @@ TEST_CASE("Parser with CommonFlags::Debug", "[common_flags]")
     test_flag<CLArgs::CommonFlags::Debug, "--debug">();
 }
 
+TEST_CASE("Parser with CommonFlags::Experimental", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Experimental, "--experimental">();
+}
+
+TEST_CASE("Parser with CommonFlags::Force", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Force, "--force", "-f">();
+}
+
+TEST_CASE("Parser with CommonFlags::Help", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Help, "--help", "-h">();
+}
+
 TEST_CASE("Parser with CommonFlags::Overwrite", "[common_flags]")
 {
     test_flag<CLArgs::CommonFlags::Overwrite, "--overwrite">();
+}
+
+TEST_CASE("Parser with CommonFlags::Parallel", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Parallel, "--parallel">();
+}
+
+TEST_CASE("Parser with CommonFlags::Profile", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Profile, "--profile">();
+}
+
+TEST_CASE("Parser with CommonFlags::Quiet", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Quiet, "--quiet", "-q">();
+}
+
+TEST_CASE("Parser with CommonFlags::Recursive", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Recursive, "--recursive", "-r">();
+}
+
+TEST_CASE("Parser with CommonFlags::Verbose", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Verbose, "--verbose", "-v">();
+}
+
+TEST_CASE("Parser with CommonFlags::Version", "[common_flags]")
+{
+    test_flag<CLArgs::CommonFlags::Version, "--version">();
 }

--- a/tests/common_flags_tests.cpp
+++ b/tests/common_flags_tests.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("Parser with CommonFlags::Verbose", "[flag_parsing]")
 {
-    CLArgs::Parser parser = CLArgs::ParserBuilder{}.add_flag<CLArgs::CommonFlags::Verbose>().build();
+    auto parser = CLArgs::ParserBuilder{}.add_flag<CLArgs::CommonFlags::Verbose>().build();
 
     SECTION("Not passed")
     {

--- a/tests/common_options_tests.cpp
+++ b/tests/common_options_tests.cpp
@@ -5,7 +5,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
-#include <string_view>
 
 template <CLArgs::CmdOption Option>
 using OptionTesterParser = decltype(CLArgs::ParserBuilder{}.add_option<Option>().build());
@@ -54,4 +53,49 @@ test_option()
 TEST_CASE("Parser with CommonOptions::Config", "[common_options]")
 {
     test_option<CLArgs::CommonOptions::Config, "conf.ini", "--configuration", "--config">();
+}
+
+TEST_CASE("Parser with CommonOptions::Output", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Output, "out.txt", "--output", "-o">();
+}
+
+TEST_CASE("Parser with CommonOptions::Input", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Input, "in.txt", "--input", "-i">();
+}
+
+TEST_CASE("Parser with CommonOptions::Timeout", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Timeout, "10", "--timeout">();
+}
+
+TEST_CASE("Parser with CommonOptions::Ip", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Ip, "127.0.0.1", "--ip", "--address">();
+}
+
+TEST_CASE("Parser with CommonOptions::Port", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Port, "6969", "--port">();
+}
+
+TEST_CASE("Parser with CommonOptions::Threads", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Threads, "12", "--threads">();
+}
+
+TEST_CASE("Parser with CommonOptions::Username", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Username, "donald_duck", "--username", "--user">();
+}
+
+TEST_CASE("Parser with CommonOptions::Password", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Password, "opensaysm3", "--password", "--pass">();
+}
+
+TEST_CASE("Parser with CommonOptions::MaxRetries", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::MaxRetries, "2000", "--max-retries">();
 }

--- a/tests/common_options_tests.cpp
+++ b/tests/common_options_tests.cpp
@@ -10,7 +10,7 @@ template <CLArgs::CmdOption Option>
 using OptionTesterParser = decltype(CLArgs::ParserBuilder{}.add_option<Option>().build());
 
 template <CLArgs::CmdOption Option>
-constexpr void
+void
 test_option_not_passed()
 {
     SECTION("Flag not passed to parser")
@@ -24,7 +24,7 @@ test_option_not_passed()
 }
 
 template <CLArgs::CmdOption Option, CLArgs::StringLiteral Value, CLArgs::StringLiteral Identifier, CLArgs::StringLiteral... Identifiers>
-constexpr void
+void
 test_option_passed()
 {
     SECTION("Pass argument \"" + std::string(Identifier.value) + "\" to parser")
@@ -43,7 +43,7 @@ test_option_passed()
 }
 
 template <CLArgs::CmdOption Option, CLArgs::StringLiteral Value, CLArgs::StringLiteral... Identifiers>
-constexpr void
+void
 test_option()
 {
     test_option_not_passed<Option>();

--- a/tests/common_options_tests.cpp
+++ b/tests/common_options_tests.cpp
@@ -1,0 +1,57 @@
+#include <CLArgs/common_options.hpp>
+#include <CLArgs/parser_builder.hpp>
+#include "test_utils.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <string_view>
+
+template <CLArgs::CmdOption Option>
+using OptionTesterParser = decltype(CLArgs::ParserBuilder{}.add_option<Option>().build());
+
+template <CLArgs::CmdOption Option>
+constexpr void
+test_option_not_passed()
+{
+    SECTION("Flag not passed to parser")
+    {
+        OptionTesterParser<Option> parser;
+        constexpr std::array       args = {"program"};
+        auto [argc, argv]               = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK_FALSE(parser.template get_option<Option>().has_value());
+    }
+}
+
+template <CLArgs::CmdOption Option, CLArgs::StringLiteral Value, CLArgs::StringLiteral Identifier, CLArgs::StringLiteral... Identifiers>
+constexpr void
+test_option_passed()
+{
+    SECTION("Pass argument \"" + std::string(Identifier.value) + "\" to parser")
+    {
+        OptionTesterParser<Option> parser;
+        constexpr std::array       args = {"program", Identifier.value, Value.value};
+        auto [argc, argv]               = CLArgs::Testing::create_argc_argv_from_array(args);
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK(parser.template get_option<Option>().has_value());
+    }
+
+    if constexpr (sizeof...(Identifiers) > 0)
+    {
+        test_option_passed<Option, Value, Identifiers...>();
+    }
+}
+
+template <CLArgs::CmdOption Option, CLArgs::StringLiteral Value, CLArgs::StringLiteral... Identifiers>
+constexpr void
+test_option()
+{
+    test_option_not_passed<Option>();
+    test_option_passed<Option, Value, Identifiers...>();
+}
+
+TEST_CASE("Parser with CommonOptions::Config", "[common_options]")
+{
+    test_option<CLArgs::CommonOptions::Config, "conf.ini", "--configuration", "--config">();
+}

--- a/tests/parser_builder_tests.cpp
+++ b/tests/parser_builder_tests.cpp
@@ -17,13 +17,13 @@ TEST_CASE("Parser builder", "[parser_builder]")
     constexpr std::array args = {"program", "-v", "--config", "test.txt", "--recursive"};
     auto [argc, argv]         = CLArgs::Testing::create_argc_argv_from_array(args);
 
-    CLArgs::Parser parser = CLArgs::ParserBuilder{}
-                                .add_flag<VerboseFlag>()
-                                .add_flag<QuietFlag>()
-                                .add_flag<RecursiveFlag>()
-                                .add_option<ConfigOption>()
-                                .add_option<NameOption>()
-                                .build();
+    auto parser = CLArgs::ParserBuilder{}
+                      .add_flag<VerboseFlag>()
+                      .add_flag<QuietFlag>()
+                      .add_flag<RecursiveFlag>()
+                      .add_option<ConfigOption>()
+                      .add_option<NameOption>()
+                      .build();
 
     REQUIRE_FALSE(parser.has_flag<VerboseFlag>());
     REQUIRE_FALSE(parser.has_flag<QuietFlag>());


### PR DESCRIPTION
# Description
A lot of programs support the same basic flags and options, for exampe "--help", "--verbose" and "--input <filepath>". It makes sense for the library to offer a set of these basic flags and options ready for use so users don't necessarily have to create custom flags and options for everything. They can simply be added to the parser builder and used directly:

```cpp
auto parser = CLArgs::ParserBuilder{}
    .add_flag<CLArgs::CommonFlags::Verbose>()
    .add_option<CLArgs::CommonOptions::Input>()
    .add_option<UserDefinedCustomOption>()
    .build();

...

if (parser.has_flag<CLArgs::CommonFlags::Verbose>())
{
    // Enable verbose output
}

```

# Related Issues
Closes #32.

# How Has This Been Tested?
I implemented tests for all common flags and options I added. The tests themselves do not check behavior in cases like ill-formed values or unknown arguments, these are already handled in other tests. Instead, these simply focus on verifying that the flag and option types can be used with the parser, and that the values are properly set for any of their supported identifiers.